### PR TITLE
Housekeeping : dotnet version update

### DIFF
--- a/src/ReactiveMarbles.Command.Tests/ReactiveMarbles.Command.Tests.csproj
+++ b/src/ReactiveMarbles.Command.Tests/ReactiveMarbles.Command.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/ReactiveMarbles.Command/ReactiveMarbles.Command.csproj
+++ b/src/ReactiveMarbles.Command/ReactiveMarbles.Command.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target frameworks for the projects in the repository to ensure compatibility with newer .NET versions. The changes include updating both the test project and the main project to target more recent frameworks.

### Target framework updates:

* [`src/ReactiveMarbles.Command.Tests/ReactiveMarbles.Command.Tests.csproj`](diffhunk://#diff-d227427321ffee6ac992fea67d79cca89037a280aa0ba01f2dbf849043974df6L4-R4): Updated the target framework from `net6.0` to `net8.0` for the test project.
* [`src/ReactiveMarbles.Command/ReactiveMarbles.Command.csproj`](diffhunk://#diff-fe981aec08fbafebc4d4168e4fe4f64beadf5ccf8a231ea471405d6ab9f4d340L4-R4): Updated the target frameworks from `netstandard2.0;net6.0;net7.0` to `netstandard2.0;net8.0;net9.0` for the main project.